### PR TITLE
Add WPL17 model support

### DIFF
--- a/esphome/ci_heatingpump_s2.yaml
+++ b/esphome/ci_heatingpump_s2.yaml
@@ -10,6 +10,7 @@ substitutions:
   can_miso_pin: GPIO19
   can_cs_pin: GPIO5
   can_id_pc: "0x680"
+  can_bit_rate: 20kbps
 
 packages:
   board: !include ha-stiebel-control/board_esp32s2.yaml

--- a/esphome/ci_heatingpump_s3.yaml
+++ b/esphome/ci_heatingpump_s3.yaml
@@ -8,6 +8,7 @@ substitutions:
   can_tx_pin: GPIO15
   can_rx_pin: GPIO16
   can_id_pc: "0x680"
+  can_bit_rate: 20kbps
 
 packages:
   board: !include ha-stiebel-control/board_esp32s3.yaml

--- a/esphome/ha-stiebel-control/can_esp32.yaml
+++ b/esphome/ha-stiebel-control/can_esp32.yaml
@@ -15,7 +15,7 @@ canbus:
     rx_pin: ${can_rx_pin}
     can_id: ${can_id_pc}
     use_extended_id: false
-    bit_rate: 20kbps
+    bit_rate: ${can_bit_rate}
     # Increased buffer sizes to prevent overflows
     # ESP32-S3 has much larger buffers than MCP2515 (2 RX buffers)
     rx_queue_len: 256  # Default: 8, increased for high-traffic CAN bus

--- a/esphome/ha-stiebel-control/can_mcp2515.yaml
+++ b/esphome/ha-stiebel-control/can_mcp2515.yaml
@@ -26,7 +26,7 @@ canbus:
     cs_pin: ${can_cs_pin}
     can_id: ${can_id_pc}
     use_extended_id: false
-    bit_rate: 20kbps
+    bit_rate: ${can_bit_rate}
     on_frame:
       - can_id: 0
         can_id_mask: 0

--- a/esphome/ha-stiebel-control/elster/ElsterTable.h
+++ b/esphome/ha-stiebel-control/elster/ElsterTable.h
@@ -1598,8 +1598,8 @@ static const ElsterIndex ElsterTable[] =
   { "TEST_OBJEKT_33", 0x0662, 0, "Test Objekt 33", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
   { "TEST_OBJEKT_34", 0x0663, 0, "Test Objekt 34", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
   { "TEST_OBJEKT_35", 0x0664, 0, "Test Objekt 35", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
-  { "TEST_OBJEKT_36", 0x0665, 0, "Test Objekt 36", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
-  { "TEST_OBJEKT_37", 0x0666, 0, "Test Objekt 37", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "AUSLEGUNGSTEMPERATUR", 0x0665, et_dec_val, "Auslegungstemperatur", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false }, // WPL17/23; was TEST_OBJEKT_36 — ported from OneESP32ToRuleThemAll, unverified
+  { "WAERMEBEDARF", 0x0666, et_dec_val, "Wärmebedarf", "sensor", "", "kW", "measurement", "mdi:fire", NULL, NULL, false, true }, // WPL17/23; was TEST_OBJEKT_37 — ported, unverified
   { "TEST_OBJEKT_38", 0x0667, 0, "Test Objekt 38", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
   { "TEST_OBJEKT_39", 0x0668, 0, "Test Objekt 39", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
   { "TEST_OBJEKT_40", 0x0669, 0, "Test Objekt 40", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
@@ -1622,9 +1622,9 @@ static const ElsterIndex ElsterTable[] =
   { "TEST_OBJEKT_57", 0x067a, 0, "Test Objekt 57", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
   { "TEST_OBJEKT_58", 0x067b, 0, "Test Objekt 58", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
   { "TEST_OBJEKT_59", 0x067c, 0, "Test Objekt 59", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
-  { "TEST_OBJEKT_60", 0x067d, 0, "Test Objekt 60", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "STANDBY_PUMPENLEISTUNG", 0x067d, 0, "Standby Pumpenleistung", "sensor", "", "%", "measurement", "mdi:water-percent", NULL, NULL, false, true }, // WPL17/23; was TEST_OBJEKT_60 — ported, unverified
   { "TEST_OBJEKT_61", 0x067e, 0, "Test Objekt 61", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
-  { "TEST_OBJEKT_62", 0x067f, 0, "Test Objekt 62", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "MAXIMALE_PUMPENLEISTUNG", 0x067f, 0, "Maximale Pumpenleistung", "sensor", "", "%", "measurement", "mdi:water-percent", NULL, NULL, false, true }, // WPL17/23; was TEST_OBJEKT_62 — ported, unverified
   { "TEST_OBJEKT_63", 0x0680, 0, "Test Objekt 63", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
   { "TEST_OBJEKT_64", 0x0681, 0, "Test Objekt 64", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
   { "TEST_OBJEKT_65", 0x0682, 0, "Test Objekt 65", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
@@ -1674,10 +1674,10 @@ static const ElsterIndex ElsterTable[] =
   { "TEST_OBJEKT_109", 0x06ae, 0, "Test Objekt 109", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
   { "TEST_OBJEKT_110", 0x06af, 0, "Test Objekt 110", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
   { "TEST_OBJEKT_111", 0x06b0, 0, "Test Objekt 111", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
-  { "TEST_OBJEKT_112", 0x06b1, 0, "Test Objekt 112", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
-  { "TEST_OBJEKT_113", 0x06b2, 0, "Test Objekt 113", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "SPANNUNG_INVERTER", 0x06b1, et_dec_val, "Spannung Inverter", "sensor", "voltage", "V", "measurement", NULL, NULL, NULL, false, true }, // WPL17/23; was TEST_OBJEKT_112 — ported, unverified
+  { "STROM_INVERTER", 0x06b2, et_dec_val, "Strom Inverter", "sensor", "current", "A", "measurement", NULL, NULL, NULL, false, true }, // WPL17/23; was TEST_OBJEKT_113 — ported, unverified
   { "TEST_OBJEKT_114", 0x06b3, 0, "Test Objekt 114", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
-  { "TEST_OBJEKT_115", 0x06b4, 0, "Test Objekt 115", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "STROM_MOTOR", 0x06b4, et_dec_val, "Strom Motor", "sensor", "current", "A", "measurement", NULL, NULL, NULL, false, true }, // WPL17/23; was TEST_OBJEKT_115 — ported, unverified
   { "TEST_OBJEKT_116", 0x06b5, 0, "Test Objekt 116", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
   { "TEST_OBJEKT_117", 0x06b6, 0, "Test Objekt 117", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
   { "TEST_OBJEKT_118", 0x06b7, 0, "Test Objekt 118", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
@@ -1714,7 +1714,7 @@ static const ElsterIndex ElsterTable[] =
   { "TEST_OBJEKT_149", 0x06d6, 0, "Test Objekt 149", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
   { "TEST_OBJEKT_150", 0x06d7, 0, "Test Objekt 150", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
   { "TEST_OBJEKT_151", 0x06d8, 0, "Test Objekt 151", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
-  { "TEST_OBJEKT_152", 0x06d9, 0, "Test Objekt 152", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "VERDICHTER_EINTRITTSTEMP", 0x06d9, et_dec_val, "Verdichter Eintrittstemperatur", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false }, // WPL17/23; was TEST_OBJEKT_152 — ported, unverified
   { "TEST_OBJEKT_153", 0x06da, 0, "Test Objekt 153", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
   { "TEST_OBJEKT_154", 0x06db, 0, "Test Objekt 154", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
   { "TEST_OBJEKT_155", 0x06dc, 0, "Test Objekt 155", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
@@ -1732,8 +1732,8 @@ static const ElsterIndex ElsterTable[] =
   { "TEST_OBJEKT_167", 0x06e8, 0, "Test Objekt 167", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
   { "TEST_OBJEKT_168", 0x06e9, 0, "Test Objekt 168", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
   { "TEST_OBJEKT_169", 0x06ea, 0, "Test Objekt 169", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
-  { "TEST_OBJEKT_170", 0x06eb, 0, "Test Objekt 170", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
-  { "TEST_OBJEKT_171", 0x06ec, 0, "Test Objekt 171", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "ISTDREHZAHL_VERDICHTER", 0x06eb, 0, "Ist Drehzahl Verdichter", "sensor", "", "Hz", "measurement", "mdi:engine", NULL, NULL, false, true }, // WPL17/23; was TEST_OBJEKT_170 — ported, unverified
+  { "SOLLDREHZAHL_VERDICHTER", 0x06ec, 0, "Soll Drehzahl Verdichter", "sensor", "", "Hz", "measurement", "mdi:engine", NULL, NULL, false, true }, // WPL17/23; was TEST_OBJEKT_171 — ported, unverified
   { "TEST_OBJEKT_172", 0x06ed, 0, "Test Objekt 172", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
   { "TEST_OBJEKT_173", 0x06ee, 0, "Test Objekt 173", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
   { "TEST_OBJEKT_174", 0x06ef, 0, "Test Objekt 174", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
@@ -1758,7 +1758,7 @@ static const ElsterIndex ElsterTable[] =
   { "TEST_OBJEKT_193", 0x0702, 0, "Test Objekt 193", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
   { "TEST_OBJEKT_194", 0x0703, 0, "Test Objekt 194", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
   { "TEST_OBJEKT_195", 0x0704, 0, "Test Objekt 195", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
-  { "TEST_OBJEKT_196", 0x0705, 0, "Test Objekt 196", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "LEISTUNG_WARMWASSERPUMPE_WPL", 0x0705, 0, "Leistung Warmwasserpumpe (WPL)", "sensor", "", "%", "measurement", "mdi:water-percent", NULL, NULL, false, true }, // WPL17/23; was TEST_OBJEKT_196 — ported, unverified. Suffixed: LEISTUNG_WARMWASSERPUMPE already used (0x070b) by WPC7.
   { "TEST_OBJEKT_197", 0x0706, 0, "Test Objekt 197", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
   { "TEST_OBJEKT_198", 0x0707, 0, "Test Objekt 198", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
   { "TEST_OBJEKT_199", 0x0708, 0, "Test Objekt 199", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
@@ -3791,6 +3791,59 @@ static const ElsterIndex ElsterTable[] =
   { "INFOBLOCK_4", 0xfe05, 0, "Infoblock 4", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
   { "INFOBLOCK_5", 0xfe06, 0, "Infoblock 5", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
   { "INFOBLOCK_6", 0xfe07, 0, "Infoblock 6", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+
+  // --------------------------------------------------------------------
+  // WPL17 / WPL23 — additional new signals (curated subset: monitoring,
+  // runtime counters, PID/EXV control, operating state — excludes raw
+  // relay outputs, stepper-motor phases, and X1 terminal config registers).
+  // Ported from community project kr0ner/OneESP32ToRuleThemAll (CAN
+  // register map; not yet verified on real WPL17/WPL23 hardware in this
+  // project). See signal_requests_wpl17.h / signal_requests_wpl23.h.
+  // --------------------------------------------------------------------
+  { "ISTTEMPERATUR", 0x4eb4, et_dec_val, "Ist Temperatur Heizkreis", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "SOLLTEMPERATUR", 0x4eb0, et_dec_val, "Soll Temperatur Heizkreis", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "KOMFORTTEMPERATUR", 0x4eb8, et_dec_val, "Komforttemperatur Heizkreis", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "ECOTEMPERATUR", 0x4eb9, et_dec_val, "Ecotemperatur Heizkreis", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "RAUMISTTEMP_WPL", 0x4ec7, et_dec_val, "Raum Ist Temperatur", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false }, // suffixed: RAUMISTTEMP already used (0x0011) by other models
+  { "RAUMFEUCHTE_WPL", 0x4ec8, et_dec_val, "Raumfeuchte", "sensor", "humidity", "%", "measurement", "mdi:water-percent", NULL, NULL, false, true }, // suffixed: RAUMFEUCHTE already used (0x0075) by WPC7
+  { "BETRIEBS_STATUS_WPL", 0x4ecd, 0, "Betriebsstatus (WPL Bitmaske)", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false }, // suffixed: BETRIEBS_STATUS already used (0x0176) by other models
+  { "RAUMSOLLTEMP", 0x4ece, et_dec_val, "Raum Soll Temperatur", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "STEIGUNG_HEIZKURVE", 0x4f2b, et_dec_val, "Steigung Heizkurve", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "VORLAUFISTTEMP_NHZ", 0x4f40, et_dec_val, "Vorlauf Ist Temperatur NHZ", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "VORLAUFISTTEMP_WP", 0x4f41, et_dec_val, "Vorlauf Ist Temperatur Wärmepumpe", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "RUECKLAUFISTTEMP_WP", 0x4f43, et_dec_val, "Rücklauf Ist Temperatur Wärmepumpe", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "KUEHLEN_ISTTEMP", 0x4f44, et_dec_val, "Kühlen Ist Temperatur", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "KUEHLEN_SOLLTEMP", 0x4f45, et_dec_val, "Kühlen Soll Temperatur", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "HEIZUNGSDRUCK", 0x4f46, et_cent_val, "Heizungsdruck", "sensor", "pressure", "bar", "measurement", "mdi:water-pressure", NULL, NULL, false, true },
+  { "VOLUMENSTROM_WPL", 0x4f47, et_cent_val, "Volumenstrom", "sensor", "", "l/min", "measurement", "mdi:flow", NULL, NULL, false, true }, // suffixed: VOLUMENSTROM already used (0x01da) by other models
+  { "RUECKLAUFTEMP_QUELLE", 0x4fa6, et_dec_val, "Rücklauftemperatur Quelle", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "VORLAUFTEMP_QUELLE", 0x4fa7, et_dec_val, "Vorlauftemperatur Quelle", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "QUELLENDRUCK_WPL", 0x4fa8, et_dec_val, "Quellendruck", "sensor", "pressure", "bar", "measurement", "mdi:water-pressure", NULL, NULL, false, true }, // suffixed: QUELLENDRUCK already used (0x0675) by WPC7
+  { "LEISTUNG_QUELLENPUMPE", 0x4fa9, et_dec_val, "Leistung Quellenpumpe", "sensor", "", "%", "measurement", "mdi:water-percent", NULL, NULL, false, true },
+  { "HEIZEN_EFFIZIENZ_TAG", 0x501d, et_cent_val, "Heizeffizienz Tag", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "HEIZEN_EFFIZIENZ_JAHR", 0x501e, et_cent_val, "Heizeffizienz Jahr", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "SOLLDREHZAHL_LUEFTER", 0xc281, 0, "Soll Drehzahl Lüfter", "sensor", "", "Hz", "measurement", "mdi:fan", NULL, NULL, false, true },
+  { "ISTDREHZAHL_LUEFTER", 0xc283, 0, "Ist Drehzahl Lüfter", "sensor", "", "Hz", "measurement", "mdi:fan", NULL, NULL, false, true },
+  { "OEFFNUNGSGRAD_BYPASSVENT", 0xc2c3, et_dec_val, "Öffnungsgrad Bypassventil", "sensor", "", "%", "measurement", NULL, NULL, NULL, false, true },
+  { "EINGESCHALTETE_STUFEN", 0x4efa, 0, "Eingeschaltete Stufen", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "SILENT_LEISTUNG", 0x4e9f, 0, "Silent Leistung", "sensor", "", "%", "measurement", NULL, NULL, NULL, false, true },
+  { "SILENT_LUEFTER", 0x4ea0, 0, "Silent Lüfter", "sensor", "", "%", "measurement", NULL, NULL, NULL, false, true },
+  { "WAERMEPUMPE_AUS", 0x4ea1, 0, "Wärmepumpe Aus", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "WARMWASSERBETRIEB", 0x4f24, 0, "Warmwasserbetrieb", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "ANTILEGIONELLENBEHANDLUNG", 0x4f28, 0, "Antilegionellenbehandlung", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "WW_ANFORDERUNG", 0x4eb2, 0, "Warmwasser Anforderung", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "FROSTSCHUTZTEMPERATUR", 0x0a36, et_dec_val, "Frostschutztemperatur", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "WW_SOLLTEMPERATUR", 0x4ef9, et_dec_val, "Warmwasser Solltemperatur", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "WARMWASSERHYSTERESE", 0x4f25, et_dec_val, "Warmwasserhysterese", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "VERFLUESSIGER_TEMP_WPL", 0x0a37, et_dec_val, "Verflüssigertemperatur", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false }, // suffixed: VERFLUESSIGER_TEMP already used (0x059d) at a different index
+  { "OELSUMPFTEMP", 0x0a39, et_dec_val, "Ölsumpftemperatur", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false },
+  { "SOMMERBETRIEB_WPL17", 0x4f1e, 0, "Sommerbetrieb (WPL17)", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false }, // suffixed: SOMMERBETRIEB already used (0xfdb4) at a different index
+  { "VERDICHTER_STARTS_K_WPL17", 0x4ef0, 0, "Verdichter Starts, skaliert (WPL17)", NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, false }, // WPL17 and WPL23 disagree on this index; see signal_requests_wpl23.h
+  { "VERDICHTER_STARTS_WPL17", 0x4ef1, 0, "Verdichter Starts (WPL17)", "sensor", "", "", "total_increasing", "mdi:counter", NULL, NULL, false, true }, // WPL17 and WPL23 disagree on this index; see signal_requests_wpl23.h
+  { "LAUFZEIT_VD_HEIZEN_WPL17", 0x4efb, 0, "Laufzeit Verdichter Heizen (WPL17)", "sensor", "duration", "h", "total_increasing", "mdi:timer", NULL, NULL, false, true }, // WPL17 and WPL23 disagree on this index; see signal_requests_wpl23.h
+  { "LAUFZEIT_VD_KUEHLEN", 0x4efc, 0, "Laufzeit Verdichter Kühlen", "sensor", "duration", "h", "total_increasing", "mdi:timer", NULL, NULL, false, true }, // WPL17-only, not defined for WPL23 in source project
+  { "LAUFZEIT_VD_WW_WPL17", 0x4efd, 0, "Laufzeit Verdichter Warmwasser (WPL17)", "sensor", "duration", "h", "total_increasing", "mdi:timer", NULL, NULL, false, true }, // WPL17 and WPL23 disagree on this index; see signal_requests_wpl23.h
+  { "LAUFZEIT_VD_ABTAUEN_WPL17", 0x4f06, 0, "Laufzeit Verdichter Abtauen (WPL17)", "sensor", "duration", "h", "total_increasing", "mdi:timer", NULL, NULL, false, true }, // WPL17 and WPL23 disagree on this index; see signal_requests_wpl23.h
 };
 
 static const ErrorIndex ErrorList[] =

--- a/esphome/ha-stiebel-control/ha-stiebel-control.h
+++ b/esphome/ha-stiebel-control/ha-stiebel-control.h
@@ -65,6 +65,13 @@ static const CanMember CanMembers[] =
         {"PC", 0x680},
         {"FREMDGERAET", 0x700},
         {"DCF_MODUL", 0x780},
+        // Model-specific Heizmodul/FET addresses that differ from the defaults
+        // HEIZMODUL (0x500). Ported from community project
+        // kr0ner/OneESP32ToRuleThemAll (CAN addresses verified there, not yet
+        // on real hardware in this project) — see signal_requests_wpl17.h /
+        // signal_requests_wpl23.h.
+        {"HEIZMODUL_WPL", 0x514},  // WPL17/WPL23 Heizmodul
+        {"FET", 0x402},            // WPL17/WPL23 room control unit (Fernbedieneinheit)
         {"OTHER", 0x000}};
 
 typedef enum
@@ -87,6 +94,8 @@ typedef enum
     cm_pc,
     cm_fremdgeraet,
     cm_dcf_modul,
+    cm_heizmodul_wpl,
+    cm_fet,
     cm_other
 } CanMemberType;
 

--- a/esphome/ha-stiebel-control/signal_requests_wpl17.h
+++ b/esphome/ha-stiebel-control/signal_requests_wpl17.h
@@ -1,0 +1,148 @@
+/*
+ * Signal Request Table — WPL17 Heat Pump
+ *
+ * UNVERIFIED ON REAL HARDWARE. Ported from community project
+ * kr0ner/OneESP32ToRuleThemAll, re-implemented against this project's
+ * ElsterTable.h/signal_requests conventions — no code or YAML was copied
+ * verbatim. This is a curated subset of the source project's WPL17 signals:
+ * temperatures, pressures/flow, fan/compressor speed, PID/EXV control,
+ * runtime counters, and operating state. Deliberately excludes raw relay
+ * outputs (RELAIS_X_2_*), stepper-motor phases, and X1 terminal config
+ * registers — internal wiring/calibration details, not monitoring data.
+ *
+ * IMPORTANT: WPL17 runs its CAN bus at 50kbps, not the project default of
+ * 20kbps. Set `can_bit_rate: 50kbps` in your heatingpump.yaml substitutions
+ * when using this model — see can_esp32.yaml/can_mcp2515.yaml.
+ *
+ * CAN targets per the source project: Kessel (0x180), Manager (0x480),
+ * Heizmodul at 0x514 (cm_heizmodul_wpl — NOT the default HEIZMODUL/0x500),
+ * FET (0x402, room control unit), and HK1 (0x601, reusing our existing
+ * MISCHERMODUL_2/cm_mischermodul_2 — same physical address, different name
+ * in the source project).
+ *
+ * Several signals below reuse existing ElsterTable rows whose Name doesn't
+ * match the source project's name for the same Index — these are very
+ * likely the same underlying Elster signal under an older/different label
+ * from the original 2014 table. Low-confidence matches are flagged inline.
+ */
+
+#ifndef SIGNAL_REQUESTS_WPL17_H
+#define SIGNAL_REQUESTS_WPL17_H
+
+#include "config.h"
+#include "signal_requests_base.h"
+
+extern const SignalRequest signalRequests[] = {
+    SIGNAL_REQUESTS_BASE   // date/time, EVU lock, operating mode, energy counters
+
+    // ========================================================================
+    // WPL17: signals queried from KESSEL (0x180)
+    // ========================================================================
+    {"AUSSENTEMP",                 FREQ_30S,   cm_kessel},
+    {"MAX_HEIZUNG_TEMP",           FREQ_10MIN, cm_kessel},  // WPL: MAXVORLAUFTEMP
+    {"MAX_TEMP_KESSEL",            FREQ_10MIN, cm_kessel},  // WPL: MAXRUECKLAUFTEMP
+    {"PUFFERTEMP_UNTEN1",          FREQ_1MIN,  cm_kessel},  // WPL: PUFFERISTTEMPERATUR
+    {"PUFFERSOLL",                 FREQ_1MIN,  cm_kessel},  // WPL: PUFFERSOLLTEMPERATUR
+    {"BIVALENTPARALLELTEMPERATUR_HZG", FREQ_10MIN, cm_kessel},  // WPL: BIVALENZTEMPERATUR_HZG
+    {"BIVALENTPARALLELTEMPERATUR_WW",  FREQ_10MIN, cm_kessel},  // WPL: BIVALENZTEMPERATUR_WW
+    {"BIVALENZALTERNATIVTEMPERATUR_HZG", FREQ_10MIN, cm_kessel},  // WPL: EINSATZGRENZE_HZG — low confidence
+    {"BIVALENZALTERNATIVTEMPERATUR_WW",  FREQ_10MIN, cm_kessel},  // WPL: EINSATZGRENZE_WW — low confidence
+    {"MAX_WW_TEMP",                FREQ_10MIN, cm_kessel},  // WPL: MAXIMALE_VORLAUFTEMP_WW
+    {"WPVORLAUFIST",               FREQ_30S,   cm_kessel},  // WPL: VORLAUFTEMP (already used by WPF10 too)
+    {"VORLAUFISTTEMP_WP",          FREQ_30S,   cm_kessel},
+    {"RUECKLAUFISTTEMP_WP",        FREQ_30S,   cm_kessel},
+    {"KUEHLEN_SOLLTEMP",           FREQ_1MIN,  cm_kessel},
+    {"KUEHLEN_ISTTEMP",            FREQ_1MIN,  cm_kessel},
+    {"AUSSEN_FROSTTEMP",           FREQ_10MIN, cm_kessel},  // WPL: ANLAGEFROST
+    {"FROSTSCHUTZTEMPERATUR",      FREQ_10MIN, cm_kessel},
+    {"VORLAUFISTTEMP_NHZ",         FREQ_30S,   cm_kessel},
+    {"AUSLEGUNGSTEMPERATUR",       FREQ_10MIN, cm_kessel},
+    {"WARMWASSERHYSTERESE",        FREQ_10MIN, cm_kessel},
+    {"WW_SOLLTEMPERATUR",          FREQ_1MIN,  cm_kessel},
+    {"HEIZUNGSDRUCK",              FREQ_30S,   cm_kessel},
+    {"VOLUMENSTROM_WPL",           FREQ_30S,   cm_kessel},
+    {"EINGESCHALTETE_STUFEN",      FREQ_10MIN, cm_kessel},  // source targets Manager — see Manager section below
+    {"SILENT_LEISTUNG",            FREQ_10MIN, cm_kessel},
+    {"SILENT_LUEFTER",             FREQ_10MIN, cm_kessel},
+    {"WAERMEPUMPE_AUS",            FREQ_10MIN, cm_kessel},
+    {"SOMMERBETRIEB_WPL17",        FREQ_1MIN,  cm_kessel},
+    {"WARMWASSERBETRIEB",          FREQ_10MIN, cm_kessel},
+    {"ANTILEGIONELLENBEHANDLUNG",  FREQ_10MIN, cm_kessel},
+    {"WW_ANFORDERUNG",             FREQ_1MIN,  cm_kessel},
+    {"LAUFZEIT_VD_HEIZEN_WPL17",   FREQ_10MIN, cm_kessel},
+    {"LAUFZEIT_VD_WW_WPL17",       FREQ_10MIN, cm_kessel},
+    {"LAUFZEIT_VD_KUEHLEN",        FREQ_10MIN, cm_kessel},
+    {"LAUFZEIT_VD_ABTAUEN_WPL17",  FREQ_10MIN, cm_kessel},
+
+    // ========================================================================
+    // WPL17: signals queried from MANAGER (0x480)
+    // ========================================================================
+    {"HEIZEN_EFFIZIENZ_TAG",       FREQ_10MIN, cm_manager},
+    {"HEIZEN_EFFIZIENZ_JAHR",      FREQ_10MIN, cm_manager},
+    {"EINGESCHALTETE_STUFEN",      FREQ_10MIN, cm_manager},
+
+    // ========================================================================
+    // WPL17: signals queried from HEIZMODUL_WPL (0x514)
+    // ========================================================================
+    {"VERDAMPFERISTTEMP_KOMPENSIERT", FREQ_1MIN,  cm_heizmodul_wpl},  // WPL: VERDAMPFERTEMP — low confidence
+    {"WE_KONFIGURATION",           FREQ_10MIN, cm_heizmodul_wpl},  // WPL17: WP_WASSERVOLUMENSTROM — low confidence
+    {"LUEFTERDREHZAHL",            FREQ_1MIN,  cm_heizmodul_wpl},  // WPL17: LUEFTERLEISTUNG_REL — low confidence
+    {"SOLLDREHZAHL_LUEFTER",       FREQ_1MIN,  cm_heizmodul_wpl},
+    {"ISTDREHZAHL_LUEFTER",        FREQ_1MIN,  cm_heizmodul_wpl},
+    {"LAUFZEIT_DHC1",              FREQ_10MIN, cm_heizmodul_wpl},  // WPL17: LAUFZEIT_NHZ1 — likely match
+    {"LAUFZEIT_DHC2",              FREQ_10MIN, cm_heizmodul_wpl},  // WPL17: LAUFZEIT_NHZ2 — likely match
+    {"LZ_DHC12",                   FREQ_10MIN, cm_heizmodul_wpl},  // WPL17: LAUFZEIT_NHZ1_2 — likely match
+    {"ZEITDAUER_LETZTE_ABTAUUNG",  FREQ_10MIN, cm_heizmodul_wpl},  // WPL17: ZEIT_ABTAUEN — likely match
+    {"STARTS_ABTAUUNG",            FREQ_10MIN, cm_heizmodul_wpl},  // WPL17: STARTS_ABTAUEN — likely match
+    {"P_ANTEIL_EXV",                FREQ_10MIN, cm_heizmodul_wpl},  // WPL17: P_FAKTOR
+    {"I_ANTEIL_EXV",                FREQ_10MIN, cm_heizmodul_wpl},  // WPL17: I_FAKTOR
+    {"D_ANTEIL_EXV",                FREQ_10MIN, cm_heizmodul_wpl},  // WPL17: D_FAKTOR
+    {"VORSTEUER_OEFFNUNGSGRAD",     FREQ_1MIN,  cm_heizmodul_wpl},  // WPL17: VORSTEUER_OEFFNUNGSGRAD_EXV
+    {"EXV_OEFFNUNGSGRAD",           FREQ_1MIN,  cm_heizmodul_wpl},  // WPL17: OEFFNUNGSGRAD_EXV
+    {"OEFFNUNGSGRAD_BYPASSVENT",    FREQ_1MIN,  cm_heizmodul_wpl},
+    {"MAXIMALE_PUMPENLEISTUNG",     FREQ_10MIN, cm_heizmodul_wpl},
+    {"STANDBY_PUMPENLEISTUNG",      FREQ_10MIN, cm_heizmodul_wpl},
+    {"LEISTUNG_WARMWASSERPUMPE_WPL", FREQ_1MIN, cm_heizmodul_wpl},
+    {"SOLLWERT_UEBERHITZUNG",       FREQ_1MIN,  cm_heizmodul_wpl},  // WPL17: SOLL_UEBERHITZUNG
+    {"ISTWERT_UEBERHITZUNG_VERDAMPFER", FREQ_1MIN, cm_heizmodul_wpl},  // WPL17: IST_UEBERHITZUNG_V
+    {"INTEGRAL_REGELABWEICHUNG",    FREQ_1MIN,  cm_heizmodul_wpl},  // WPL17: REGELABWEICHUNG — low confidence
+    {"SPANNUNG_INVERTER",           FREQ_1MIN,  cm_heizmodul_wpl},
+    {"STROM_INVERTER",              FREQ_1MIN,  cm_heizmodul_wpl},
+    {"STROM_MOTOR",                 FREQ_1MIN,  cm_heizmodul_wpl},
+    {"VERDICHTER_EINTRITTSTEMP",    FREQ_1MIN,  cm_heizmodul_wpl},
+    {"ISTDREHZAHL_VERDICHTER",      FREQ_30S,   cm_heizmodul_wpl},
+    {"SOLLDREHZAHL_VERDICHTER",     FREQ_30S,   cm_heizmodul_wpl},
+    {"ANZEIGE_HOCHDRUCK",           FREQ_30S,   cm_heizmodul_wpl},  // WPL: DRUCK_HOCHDRUCK
+    {"ANZEIGE_NIEDERDRUCK",         FREQ_30S,   cm_heizmodul_wpl},  // WPL: DRUCK_NIEDERDRUCK
+    {"RUECKLAUFTEMP_QUELLE",        FREQ_1MIN,  cm_heizmodul_wpl},
+    {"VORLAUFTEMP_QUELLE",          FREQ_1MIN,  cm_heizmodul_wpl},
+    {"QUELLENDRUCK_WPL",            FREQ_1MIN,  cm_heizmodul_wpl},
+    {"LEISTUNG_QUELLENPUMPE",       FREQ_1MIN,  cm_heizmodul_wpl},
+    {"VERDICHTER_STARTS_WPL17",     FREQ_10MIN, cm_heizmodul_wpl},
+    {"VERDICHTER_STARTS_K_WPL17",   FREQ_10MIN, cm_heizmodul_wpl},
+    {"LAUFZEIT_NHZ1",               FREQ_10MIN, cm_heizmodul_wpl},  // bare property also exists; see LAUFZEIT_DHC1 above
+    {"LAUFZEIT_NHZ2",               FREQ_10MIN, cm_heizmodul_wpl},
+    {"LAUFZEIT_NHZ1_2",             FREQ_10MIN, cm_heizmodul_wpl},
+    {"ZEIT_ABTAUEN",                FREQ_10MIN, cm_heizmodul_wpl},
+    {"STARTS_ABTAUEN",              FREQ_10MIN, cm_heizmodul_wpl},
+
+    // ========================================================================
+    // WPL17: signals queried from FET (0x402, room control unit)
+    // ========================================================================
+    {"RAUMISTTEMP_WPL",            FREQ_1MIN,  cm_fet},
+    {"RAUMFEUCHTE_WPL",            FREQ_10MIN, cm_fet},
+    {"RAUMSOLLTEMP",               FREQ_1MIN,  cm_fet},
+
+    // ========================================================================
+    // WPL17: signals queried from HK1 (0x601 — reuses MISCHERMODUL_2)
+    // ========================================================================
+    {"ISTTEMPERATUR",              FREQ_1MIN,  cm_mischermodul_2},
+    {"SOLLTEMPERATUR",             FREQ_1MIN,  cm_mischermodul_2},
+    {"KOMFORTTEMPERATUR",          FREQ_10MIN, cm_mischermodul_2},
+    {"ECOTEMPERATUR",              FREQ_10MIN, cm_mischermodul_2},
+    {"STEIGUNG_HEIZKURVE",         FREQ_10MIN, cm_mischermodul_2},
+};
+
+extern const size_t SIGNAL_REQUEST_COUNT_VALUE = sizeof(signalRequests) / sizeof(SignalRequest);
+
+#endif // SIGNAL_REQUESTS_WPL17_H

--- a/esphome/ha-stiebel-control/wpl17.yaml
+++ b/esphome/ha-stiebel-control/wpl17.yaml
@@ -1,0 +1,19 @@
+#
+#  WPL17 Heat Pump — Model Package
+#
+#  Selects the WPL17 signal request table (SIGNAL_REQUESTS_BASE + WPL17-specific
+#  signals). All universal sensors live in common.yaml.
+#
+#  IMPORTANT: WPL17 needs can_bit_rate: 50kbps in heatingpump.yaml substitutions
+#  (the project default is 20kbps). See signal_requests_wpl17.h header comment.
+#
+#  UNVERIFIED ON REAL HARDWARE — see signal_requests_wpl17.h header comment.
+#  Please test against a real unit before relying on it.
+#
+#  To add a new model, create signal_requests_yourmodel.h and a thin yourmodel.yaml
+#  following this pattern. See CONTRIBUTING.md for full instructions.
+#
+
+esphome:
+  includes:
+    - ha-stiebel-control/signal_requests_wpl17.h

--- a/esphome/heatingpump.yaml
+++ b/esphome/heatingpump.yaml
@@ -19,6 +19,7 @@ substitutions:
   can_tx_pin: GPIO15  # TXD2 on Waveshare board
   can_rx_pin: GPIO16  # RXD2 on Waveshare board
   can_id_pc: "0x680"
+  can_bit_rate: 20kbps             # 20kbps (WPL13E, WPF10, WPC7); WPL17/WPL23 need 50kbps
 
 packages:
   board: !include ha-stiebel-control/board_esp32s3.yaml
@@ -40,6 +41,7 @@ packages:
 #   can_miso_pin: GPIO19
 #   can_cs_pin: GPIO5
 #   can_id_pc: "0x680"
+#   can_bit_rate: 20kbps
 #
 # packages:
 #   board: !include ha-stiebel-control/board_esp32s2.yaml

--- a/tests/models/wpl17_smoke.json
+++ b/tests/models/wpl17_smoke.json
@@ -1,0 +1,6 @@
+{
+  "description": "Required topics for WPL17. UNVERIFIED — ported from community project kr0ner/OneESP32ToRuleThemAll desk research, no physical hardware tested, and the model needs can_bit_rate: 50kbps to communicate at all. Stub — populate/correct after verifying on real hardware. See tests/models/wpl13e_smoke.json for the expected format.",
+  "required_topics": [
+    "heatingpump/KESSEL/AUSSENTEMP/state"
+  ]
+}


### PR DESCRIPTION
## Summary
- Ports a **curated subset** of the CAN register map for WPL17 from community project [kr0ner/OneESP32ToRuleThemAll](https://github.com/kr0ner/OneESP32ToRuleThemAll) (no declared license — treated as protocol facts, re-implemented against this project's own conventions, not copied verbatim, source credited in file headers)
- Included: temperatures, pressures/flow, fan/compressor speed, PID/EXV control, runtime counters, operating state
- Deliberately **excluded**: raw relay outputs (`RELAIS_X_2_*`), stepper-motor phases, X1 terminal config registers — internal wiring/calibration details, not monitoring data, easy to add later if someone needs them
- Adds `signal_requests_wpl17.h`, `wpl17.yaml`, `tests/models/wpl17_smoke.json`
- Adds two new `CanMembers`: `HEIZMODUL_WPL` (0x514) and `FET` (0x402) — WPL's Heizmodul/room-control addresses differ from this project's defaults
- Adds a `can_bit_rate` substitution to `can_esp32.yaml`/`can_mcp2515.yaml` (default unchanged at 20kbps) — **WPL17 needs `can_bit_rate: 50kbps`** in `heatingpump.yaml`, since the project previously hardcoded 20kbps
- ~20 `ElsterTable.h` entries upgrade previously-unused `TEST_OBJEKT_*` placeholders rather than adding duplicate rows; the rest are new or suffixed (`_WPL`) where a name collides with an existing entry at a different index

## Context
No open issue specifically requested WPL17, but it's a close cousin of the already-supported WPL13E and was scoped alongside the WPC7 port (#2) while investigating the OneESP32ToRuleThemAll project. This PR is independent of the WPC7 PR (no shared `CanMembers`/table rows between them).

**This is desk research, not verified on real hardware.** Several signals reuse existing `ElsterTable.h` rows under a different name at the same index (flagged inline, low-confidence matches called out) — these are very likely the same underlying Elster signal under an older label from the original 2014 table, but unconfirmed.

## Test plan
- [x] `make config` — YAML parses cleanly with `can_bit_rate: 50kbps`
- [x] `make compile` (ESP32-S3) — flash usage ~21.7%
- [x] `make compile-s2` (ESP32-S2/MCP2515) — compiles clean
- [x] `make test` — all native unit tests pass, no duplicate Name/Index introduced in `ElsterTable.h`
- [ ] **Needs a tester with a real WPL17 unit** — please flash with `can_bit_rate: 50kbps`, check ESPHome logs for which signals respond, and open an issue/comment with findings before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StMqwchiNTNzs9skrZLhHx