### PR TITLE
Add WPL23 model support

### DIFF
--- a/esphome/ha-stiebel-control/elster/ElsterTable.h
+++ b/esphome/ha-stiebel-control/elster/ElsterTable.h
@@ -3844,6 +3844,8 @@ static const ElsterIndex ElsterTable[] =
   { "LAUFZEIT_VD_KUEHLEN", 0x4efc, 0, "Laufzeit Verdichter Kühlen", "sensor", "duration", "h", "total_increasing", "mdi:timer", NULL, NULL, false, true }, // WPL17-only, not defined for WPL23 in source project
   { "LAUFZEIT_VD_WW_WPL17", 0x4efd, 0, "Laufzeit Verdichter Warmwasser (WPL17)", "sensor", "duration", "h", "total_increasing", "mdi:timer", NULL, NULL, false, true }, // WPL17 and WPL23 disagree on this index; see signal_requests_wpl23.h
   { "LAUFZEIT_VD_ABTAUEN_WPL17", 0x4f06, 0, "Laufzeit Verdichter Abtauen (WPL17)", "sensor", "duration", "h", "total_increasing", "mdi:timer", NULL, NULL, false, true }, // WPL17 and WPL23 disagree on this index; see signal_requests_wpl23.h
+  { "LAUFZEIT_VD_HEIZEN_WPL23", 0x07fc, 0, "Laufzeit Verdichter Heizen (WPL23)", "sensor", "duration", "h", "total_increasing", "mdi:timer", NULL, NULL, false, true },
+  { "LAUFZEIT_VD_WW_WPL23", 0x0802, 0, "Laufzeit Verdichter Warmwasser (WPL23)", "sensor", "duration", "h", "total_increasing", "mdi:timer", NULL, NULL, false, true },
 };
 
 static const ErrorIndex ErrorList[] =

--- a/esphome/ha-stiebel-control/signal_requests_wpl23.h
+++ b/esphome/ha-stiebel-control/signal_requests_wpl23.h
@@ -1,0 +1,128 @@
+/*
+ * Signal Request Table — WPL23 Heat Pump
+ *
+ * UNVERIFIED ON REAL HARDWARE. Ported from community project
+ * kr0ner/OneESP32ToRuleThemAll, re-implemented against this project's
+ * ElsterTable.h/signal_requests conventions — no code or YAML was copied
+ * verbatim. This is a curated subset of the source project's WPL23 signals
+ * (same shared WPL base as WPL17, plus a handful of WPL23-only signals).
+ * Deliberately excludes raw relay outputs, stepper-motor phases, and X1
+ * terminal config registers — internal wiring/calibration details, not
+ * monitoring data.
+ *
+ * Self-contained on purpose rather than sharing a macro with
+ * signal_requests_wpl17.h: WPL17 and WPL23 disagree on the Elster index for
+ * six signal names (VERDICHTER_STARTS[_K], LAUFZEIT_VD_HEIZEN/WW/ABTAUEN),
+ * and even disagree on which CAN member exposes LAUFZEIT_NHZ1/2/1_2 — a
+ * shared macro would either need per-model parameters or silently encode
+ * one model's choices as "shared", which is worse than light duplication.
+ *
+ * IMPORTANT: WPL23 runs its CAN bus at 50kbps, not the project default of
+ * 20kbps. Set `can_bit_rate: 50kbps` in your heatingpump.yaml substitutions
+ * when using this model — see can_esp32.yaml/can_mcp2515.yaml.
+ *
+ * CAN targets per the source project: Kessel (0x180), Manager (0x480),
+ * Heizmodul at 0x514 (cm_heizmodul_wpl — NOT the default HEIZMODUL/0x500),
+ * FET (0x402, room control unit), and HK1 (0x601, reusing our existing
+ * MISCHERMODUL_2/cm_mischermodul_2 — same physical address, different name
+ * in the source project).
+ *
+ * Several signals below reuse existing ElsterTable rows whose Name doesn't
+ * match the source project's name for the same Index — these are very
+ * likely the same underlying Elster signal under an older/different label
+ * from the original 2014 table. Low-confidence matches are flagged inline.
+ */
+
+#ifndef SIGNAL_REQUESTS_WPL23_H
+#define SIGNAL_REQUESTS_WPL23_H
+
+#include "config.h"
+#include "signal_requests_base.h"
+
+extern const SignalRequest signalRequests[] = {
+    SIGNAL_REQUESTS_BASE   // date/time, EVU lock, operating mode, energy counters
+
+    // ========================================================================
+    // WPL23: signals queried from KESSEL (0x180)
+    // ========================================================================
+    {"AUSSENTEMP",                 FREQ_30S,   cm_kessel},
+    {"MAX_HEIZUNG_TEMP",           FREQ_10MIN, cm_kessel},  // WPL: MAXVORLAUFTEMP
+    {"MAX_TEMP_KESSEL",            FREQ_10MIN, cm_kessel},  // WPL: MAXRUECKLAUFTEMP
+    {"PUFFERTEMP_UNTEN1",          FREQ_1MIN,  cm_kessel},  // WPL: PUFFERISTTEMPERATUR
+    {"PUFFERSOLL",                 FREQ_1MIN,  cm_kessel},  // WPL: PUFFERSOLLTEMPERATUR
+    {"BIVALENTPARALLELTEMPERATUR_HZG", FREQ_10MIN, cm_kessel},  // WPL: BIVALENZTEMPERATUR_HZG
+    {"BIVALENTPARALLELTEMPERATUR_WW",  FREQ_10MIN, cm_kessel},  // WPL: BIVALENZTEMPERATUR_WW
+    {"BIVALENZALTERNATIVTEMPERATUR_HZG", FREQ_10MIN, cm_kessel},  // WPL: EINSATZGRENZE_HZG — low confidence
+    {"BIVALENZALTERNATIVTEMPERATUR_WW",  FREQ_10MIN, cm_kessel},  // WPL: EINSATZGRENZE_WW — low confidence
+    {"MAX_WW_TEMP",                FREQ_10MIN, cm_kessel},  // WPL: MAXIMALE_VORLAUFTEMP_WW
+    {"WPVORLAUFIST",               FREQ_30S,   cm_kessel},  // WPL: VORLAUFTEMP (already used by WPF10 too)
+    {"VORLAUFISTTEMP_WP",          FREQ_30S,   cm_kessel},
+    {"RUECKLAUFISTTEMP_WP",        FREQ_30S,   cm_kessel},
+    {"KUEHLEN_SOLLTEMP",           FREQ_1MIN,  cm_kessel},
+    {"KUEHLEN_ISTTEMP",            FREQ_1MIN,  cm_kessel},
+    {"AUSSEN_FROSTTEMP",           FREQ_10MIN, cm_kessel},  // WPL: ANLAGEFROST
+    {"FROSTSCHUTZTEMPERATUR",      FREQ_10MIN, cm_kessel},
+    {"VORLAUFISTTEMP_NHZ",         FREQ_30S,   cm_kessel},
+    {"AUSLEGUNGSTEMPERATUR",       FREQ_10MIN, cm_kessel},
+    {"WARMWASSERHYSTERESE",        FREQ_10MIN, cm_kessel},
+    {"WW_SOLLTEMPERATUR",          FREQ_1MIN,  cm_kessel},
+    {"HEIZUNGSDRUCK",              FREQ_30S,   cm_kessel},
+    {"VOLUMENSTROM_WPL",           FREQ_30S,   cm_kessel},
+    {"EINGESCHALTETE_STUFEN",      FREQ_10MIN, cm_kessel},  // source targets Manager — see Manager section below
+    {"SILENT_LEISTUNG",            FREQ_10MIN, cm_kessel},
+    {"SILENT_LUEFTER",             FREQ_10MIN, cm_kessel},
+    {"WAERMEPUMPE_AUS",            FREQ_10MIN, cm_kessel},
+    {"WARMWASSERBETRIEB",          FREQ_10MIN, cm_kessel},
+    {"ANTILEGIONELLENBEHANDLUNG",  FREQ_10MIN, cm_kessel},
+    {"WW_ANFORDERUNG",             FREQ_1MIN,  cm_kessel},
+    {"VERDICHTER_STARTS",          FREQ_10MIN, cm_kessel},    // same index as WPC7 (0x071d) — see ElsterTable.h
+    {"VERDICHTER_STARTS_K",        FREQ_10MIN, cm_kessel},    // same index as WPC7 (0x071c) — see ElsterTable.h
+    {"LAUFZEIT_NHZ1",              FREQ_10MIN, cm_kessel},    // WPL23 targets Kessel; WPL17 targets Heizmodul for this name
+    {"LAUFZEIT_NHZ2",              FREQ_10MIN, cm_kessel},
+    {"LAUFZEIT_NHZ1_2",            FREQ_10MIN, cm_kessel},
+
+    // ========================================================================
+    // WPL23: signals queried from MANAGER (0x480)
+    // ========================================================================
+    {"HEIZEN_EFFIZIENZ_TAG",       FREQ_10MIN, cm_manager},
+    {"HEIZEN_EFFIZIENZ_JAHR",      FREQ_10MIN, cm_manager},
+    {"EINGESCHALTETE_STUFEN",      FREQ_10MIN, cm_manager},
+
+    // ========================================================================
+    // WPL23: signals queried from HEIZMODUL_WPL (0x514)
+    // ========================================================================
+    {"VERDAMPFERISTTEMP_KOMPENSIERT", FREQ_1MIN,  cm_heizmodul_wpl},  // WPL: VERDAMPFERTEMP — low confidence
+    {"ANZEIGE_HOCHDRUCK",           FREQ_30S,   cm_heizmodul_wpl},  // WPL: DRUCK_HOCHDRUCK
+    {"ANZEIGE_NIEDERDRUCK",         FREQ_30S,   cm_heizmodul_wpl},  // WPL: DRUCK_NIEDERDRUCK
+    {"RUECKLAUFTEMP_QUELLE",        FREQ_1MIN,  cm_heizmodul_wpl},
+    {"VORLAUFTEMP_QUELLE",          FREQ_1MIN,  cm_heizmodul_wpl},
+    {"QUELLENDRUCK_WPL",            FREQ_1MIN,  cm_heizmodul_wpl},
+    {"LEISTUNG_QUELLENPUMPE",       FREQ_1MIN,  cm_heizmodul_wpl},
+    {"REKUPERATORISTTEMP",          FREQ_1MIN,  cm_heizmodul_wpl},  // WPL23: REKUPERATORTEMPERATUR
+    {"LEISTUNGSREDUZIERUNG_KUEHLEN", FREQ_1MIN, cm_heizmodul_wpl},  // WPL23: ZWISCHENEINSPRITZUNGSTEMP — low confidence
+    {"LAUFZEIT_VD_HEIZEN_WPL23",    FREQ_10MIN, cm_heizmodul_wpl},
+    {"LAUFZEIT_VD_WW_WPL23",        FREQ_10MIN, cm_heizmodul_wpl},
+    {"ABTAUZEIT_VERD1",             FREQ_10MIN, cm_heizmodul_wpl},  // WPL23: LAUFZEIT_VD_ABTAUEN
+    {"ZEITDAUER_LETZTE_ABTAUUNG",   FREQ_10MIN, cm_heizmodul_wpl},  // WPL23: ZEIT_ABTAUEN — likely match
+    {"STARTS_ABTAUUNG",             FREQ_10MIN, cm_heizmodul_wpl},  // WPL23: STARTS_ABTAUEN — likely match
+
+    // ========================================================================
+    // WPL23: signals queried from FET (0x402, room control unit)
+    // ========================================================================
+    {"RAUMISTTEMP_WPL",            FREQ_1MIN,  cm_fet},
+    {"RAUMFEUCHTE_WPL",            FREQ_10MIN, cm_fet},
+    {"RAUMSOLLTEMP",               FREQ_1MIN,  cm_fet},
+
+    // ========================================================================
+    // WPL23: signals queried from HK1 (0x601 — reuses MISCHERMODUL_2)
+    // ========================================================================
+    {"ISTTEMPERATUR",              FREQ_1MIN,  cm_mischermodul_2},
+    {"SOLLTEMPERATUR",              FREQ_1MIN,  cm_mischermodul_2},
+    {"KOMFORTTEMPERATUR",          FREQ_10MIN, cm_mischermodul_2},
+    {"ECOTEMPERATUR",              FREQ_10MIN, cm_mischermodul_2},
+    {"STEIGUNG_HEIZKURVE",         FREQ_10MIN, cm_mischermodul_2},
+};
+
+extern const size_t SIGNAL_REQUEST_COUNT_VALUE = sizeof(signalRequests) / sizeof(SignalRequest);
+
+#endif // SIGNAL_REQUESTS_WPL23_H

--- a/esphome/ha-stiebel-control/wpl23.yaml
+++ b/esphome/ha-stiebel-control/wpl23.yaml
@@ -1,0 +1,19 @@
+#
+#  WPL23 Heat Pump — Model Package
+#
+#  Selects the WPL23 signal request table (SIGNAL_REQUESTS_BASE + WPL23-specific
+#  signals). All universal sensors live in common.yaml.
+#
+#  IMPORTANT: WPL23 needs can_bit_rate: 50kbps in heatingpump.yaml substitutions
+#  (the project default is 20kbps). See signal_requests_wpl23.h header comment.
+#
+#  UNVERIFIED ON REAL HARDWARE — see signal_requests_wpl23.h header comment.
+#  Please test against a real unit before relying on it.
+#
+#  To add a new model, create signal_requests_yourmodel.h and a thin yourmodel.yaml
+#  following this pattern. See CONTRIBUTING.md for full instructions.
+#
+
+esphome:
+  includes:
+    - ha-stiebel-control/signal_requests_wpl23.h

--- a/tests/models/wpl23_smoke.json
+++ b/tests/models/wpl23_smoke.json
@@ -1,0 +1,6 @@
+{
+  "description": "Required topics for WPL23. UNVERIFIED — ported from community project kr0ner/OneESP32ToRuleThemAll desk research, no physical hardware tested, and the model needs can_bit_rate: 50kbps to communicate at all. Stub — populate/correct after verifying on real hardware. See tests/models/wpl13e_smoke.json for the expected format.",
+  "required_topics": [
+    "heatingpump/KESSEL/AUSSENTEMP/state"
+  ]
+}


### PR DESCRIPTION
## Summary
**Stacked on #28 (WPL17)** — WPL23 is the same WPL family and reuses WPL17's `HEIZMODUL_WPL`/`FET` `CanMembers` additions and most of its `ElsterTable.h` rows. This PR's diff against `port/wpl17-model` is intentionally small: two new `ElsterTable.h` rows plus the model files.

- Adds `signal_requests_wpl23.h`, `wpl23.yaml`, `tests/models/wpl23_smoke.json`
- Adds 2 new `ElsterTable.h` rows for the indices where **WPL17 and WPL23 genuinely disagree**: `LAUFZEIT_VD_HEIZEN_WPL23` (0x07fc) and `LAUFZEIT_VD_WW_WPL23` (0x0802) — discovered by diffing the source project's own `#if defined(WPL_17)` vs `#if defined(WPL_23)` blocks; `VERDICHTER_STARTS`/`VERDICHTER_STARTS_K` happen to share WPC7's indices (0x071d/0x071c) so those rows are reused as-is, no new entry needed
- `signal_requests_wpl23.h` is fully self-contained (not a shared macro with `signal_requests_wpl17.h`) on purpose: WPL17/WPL23 disagree on 6 signal indices and on which `CanMember` exposes `LAUFZEIT_NHZ1/2/1_2` — a shared macro would either need per-model parameters or silently encode one model's choices as "shared," which is worse than the small duplication
- Same ported-from-OneESP32ToRuleThemAll, no-verbatim-copy, credited-in-headers approach as #27/#28

## Context
Scoped alongside #28 (WPL17) — same family, same source project, same curation rules (monitoring/control signals only, no raw relay/stepper/X1 registers).

**Desk research, not verified on real hardware.**

## Test plan
- [x] `make config` — YAML parses cleanly with `can_bit_rate: 50kbps`
- [x] `make compile` (ESP32-S3) — flash usage ~21.7%
- [x] `make compile-s2` (ESP32-S2/MCP2515) — compiles clean
- [x] `make test` — all native unit tests pass, no duplicate Name/Index introduced in `ElsterTable.h`
- [ ] **Needs a tester with a real WPL23 unit** before merging
- Note: should be rebased onto `main` if #28 merges first, or merged after #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StMqwchiNTNzs9skrZLhHx